### PR TITLE
add link back to github repo and wiki from home page

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -26,6 +26,7 @@ This lab manual resource is intended to provide an overview for lab members and 
 The content for this book was developed as part of our group's participation in the [Openscapes Champions program](https://openscapes.org).  
 We are extremely grateful to and acknowledge [Dr. Julia Stewart Lowndes](https://twitter.com/juliesquid)' role in helping shape how our lab both works and how we articulate our identity.  
 
+<a align="left" href="https://github.com/thefaylab/lab-manual/"><img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" width="35px"></a> < link to this book's GitHub repository. Also see [Quick steps to making a copy of the lab manual and publishing it](https://github.com/thefaylab/lab-manual/wiki/Quick-steps-to-making-a-copy-of-the-lab-manual-&-publishing-it)!
 
 
 ```{r, out.width = "25%", echo = FALSE}


### PR DESCRIPTION
Hi! There are other (better?) ways to do this but it would be awesome to link to the repo and wiki from the book :)